### PR TITLE
Extract interface out of Paper and rename implementation

### DIFF
--- a/src/main/java/de/aliceice/paper/Paper.java
+++ b/src/main/java/de/aliceice/paper/Paper.java
@@ -1,69 +1,14 @@
 package de.aliceice.paper;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-public class Paper {
+public interface Paper {
     
-    public void printTitle(String name) {
-        this.name = name;
-    }
+    void printTitle(String title);
     
-    public void printDescription(String description) {
-        this.description = description;
-    }
+    void printDescription(String description);
     
-    public void printField(String name, String description) {
-        this.printedFields.put(name, description);
-    }
+    void printField(String name, String description);
     
-    public void markAsInvalid() {
-        this.isMarkedInvalid = true;
-    }
+    void markAsInvalid();
     
-    public void markErrorOn(String name) {
-        this.markedFields.add(name);
-    }
-    
-    public void hasTitle(String name) {
-        assertEquals(name, this.name);
-    }
-    
-    public void hasDescription(String description) {
-        assertEquals(description, this.description);
-    }
-    
-    public void hasField(String name, String... rules) {
-        assertTrue(this.printedFields.containsKey(name),
-                   String.format("%s is not printed.%n Available fields are: %s",
-                                 name, this.printedFields.keySet()));
-        assertEquals(Stream.of(rules).collect(Collectors.joining(System.lineSeparator())),
-                     this.printedFields.get(name));
-        
-    }
-    
-    public void isMarkedInvalid() {
-        assertTrue(this.isMarkedInvalid);
-    }
-    
-    public void hasMarkedFields(String... fields) {
-        Stream.of(fields).forEach(field -> {
-            assertTrue(this.markedFields.contains(field),
-                       String.format("%s is not marked as invalid. Marked fields are: %s",
-                                     field, this.markedFields));
-        });
-    }
-    
-    private String              name            = "";
-    private String              description     = "";
-    private Map<String, String> printedFields   = new HashMap<>();
-    private boolean             isMarkedInvalid = false;
-    private List<String>        markedFields    = new ArrayList<>();
+    void markErrorOn(String fieldName);
 }

--- a/src/main/java/de/aliceice/paper/TestPaper.java
+++ b/src/main/java/de/aliceice/paper/TestPaper.java
@@ -1,0 +1,74 @@
+package de.aliceice.paper;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public final class TestPaper implements Paper {
+    
+    @Override
+    public void printTitle(String title) {
+        this.name = title;
+    }
+    
+    @Override
+    public void printDescription(String description) {
+        this.description = description;
+    }
+    
+    @Override
+    public void printField(String name, String description) {
+        this.printedFields.put(name, description);
+    }
+    
+    @Override
+    public void markAsInvalid() {
+        this.isMarkedInvalid = true;
+    }
+    
+    @Override
+    public void markErrorOn(String fieldName) {
+        this.markedFields.add(fieldName);
+    }
+    
+    public void hasTitle(String title) {
+        assertEquals(title, this.name);
+    }
+    
+    public void hasDescription(String description) {
+        assertEquals(description, this.description);
+    }
+    
+    public void hasField(String name, String... rules) {
+        assertTrue(this.printedFields.containsKey(name),
+                   String.format("%s is not printed.%n Available fields are: %s",
+                                 name, this.printedFields.keySet()));
+        assertEquals(Stream.of(rules).collect(Collectors.joining(System.lineSeparator())),
+                     this.printedFields.get(name));
+        
+    }
+    
+    public void isMarkedInvalid() {
+        assertTrue(this.isMarkedInvalid);
+    }
+    
+    public void hasMarkedFields(String... fields) {
+        Stream.of(fields).forEach(field -> {
+            assertTrue(this.markedFields.contains(field),
+                       String.format("%s is not marked as invalid. Marked fields are: %s",
+                                     field, this.markedFields));
+        });
+    }
+    
+    private String              name            = "";
+    private String              description     = "";
+    private Map<String, String> printedFields   = new HashMap<>();
+    private Boolean             isMarkedInvalid = false;
+    private List<String>        markedFields    = new ArrayList<>();
+}

--- a/src/test/java/de/aliceice/paper/FormTest.java
+++ b/src/test/java/de/aliceice/paper/FormTest.java
@@ -71,7 +71,7 @@ public final class FormTest {
         this.subject.write("Field 2", "Hello World!");
     }
     
-    private final Form  subject = new Form("Test Form",
+    private final Form      subject = new Form("Test Form",
                                            "Testing a form",
                                            new Fields(new Field("Field 1",
                                                                 new MandatoryRule(),
@@ -79,5 +79,5 @@ public final class FormTest {
                                                       new Field("Field 2",
                                                                 new MandatoryRule(),
                                                                 new FixedLengthRule(12))));
-    private final Paper paper   = new Paper();
+    private final TestPaper paper   = new TestPaper();
 }


### PR DESCRIPTION
To support future changes the Paper must be polymorphic.
The current implementation is used in tests to assert
that specific behaviours were triggered.
The actions taken are:
  - Extract an interface which is named 'Paper'
  - Rename current implementation to 'TestPaper'
  - Push all methods into the interface which do not assert behaviour

Issue #9