### PR TITLE
Implement console specific Paper

### DIFF
--- a/code-quality/findbugs-exclude.xml
+++ b/code-quality/findbugs-exclude.xml
@@ -1,3 +1,5 @@
 <FindBugsFilter>
 
+    <Bug pattern="DM_DEFAULT_ENCODING"/>
+
 </FindBugsFilter>

--- a/src/main/java/de/aliceice/paper/ConsolePaper.java
+++ b/src/main/java/de/aliceice/paper/ConsolePaper.java
@@ -1,0 +1,60 @@
+package de.aliceice.paper;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Scanner;
+
+public final class ConsolePaper implements Paper {
+    
+    @Override
+    public void printTitle(String title) {
+        this.out.println(title);
+    }
+    
+    @Override
+    public void printDescription(String description) {
+        this.out.println(description);
+        this.out.println();
+    }
+    
+    @Override
+    public void printField(String name, String description) {
+        this.fieldDescriptions.put(name, description);
+        this.out.printf("%s: ", name);
+        this.fieldValues.put(name, this.in.nextLine());
+    }
+    
+    @Override
+    public void markAsInvalid() {
+        this.out.println("There are errors on the form:");
+    }
+    
+    @Override
+    public void markErrorOn(String fieldName) {
+        this.out.printf("  - %s: %s", fieldName, this.fieldDescriptions.get(fieldName));
+    }
+    
+    @Override
+    public void copyTo(Form form) {
+        this.fieldValues.forEach(form::write);
+    }
+    
+    public ConsolePaper() {
+        this(System.in, System.out);
+    }
+    
+    public ConsolePaper(InputStream in, OutputStream out) {
+        this.in = new Scanner(in);
+        this.out = new PrintWriter(out, true);
+        this.fieldValues = new HashMap<>();
+        this.fieldDescriptions = new HashMap<>();
+    }
+    
+    private final Scanner             in;
+    private final PrintWriter         out;
+    private final Map<String, String> fieldValues;
+    private final Map<String, String> fieldDescriptions;
+}

--- a/src/main/java/de/aliceice/paper/Paper.java
+++ b/src/main/java/de/aliceice/paper/Paper.java
@@ -11,4 +11,6 @@ public interface Paper {
     void markAsInvalid();
     
     void markErrorOn(String fieldName);
+    
+    void copyTo(Form form);
 }

--- a/src/main/java/de/aliceice/paper/TestPaper.java
+++ b/src/main/java/de/aliceice/paper/TestPaper.java
@@ -37,6 +37,11 @@ public final class TestPaper implements Paper {
         this.markedFields.add(fieldName);
     }
     
+    @Override
+    public void copyTo(Form form) {
+        this.fieldValues.forEach(form::write);
+    }
+    
     public void hasTitle(String title) {
         assertEquals(title, this.name);
     }
@@ -66,9 +71,14 @@ public final class TestPaper implements Paper {
         });
     }
     
+    public void write(String fieldName, String value) {
+        this.fieldValues.put(fieldName, value);
+    }
+    
     private String              name            = "";
     private String              description     = "";
     private Map<String, String> printedFields   = new HashMap<>();
+    private Map<String, String> fieldValues     = new HashMap<>();
     private Boolean             isMarkedInvalid = false;
     private List<String>        markedFields    = new ArrayList<>();
 }

--- a/src/test/java/de/aliceice/paper/ConsolePaperTest.java
+++ b/src/test/java/de/aliceice/paper/ConsolePaperTest.java
@@ -1,0 +1,67 @@
+package de.aliceice.paper;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.PrintStream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(EnglishLocaleExtension.class)
+public final class ConsolePaperTest {
+    
+    @Test
+    public void printsOutputAndReadsFromInput() throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ConsolePaper subject = new ConsolePaper(new ByteArrayInputStream(String.format("Value%n").getBytes()), out);
+        
+        this.form.printOn(subject);
+        subject.copyTo(this.form);
+        
+        assertEquals(String.format("Test Form%n" +
+                                   "Test Description%n%n" +
+                                   "Test Field: "),
+                     out.toString());
+        
+        assertTrue(this.form.isValid());
+        this.form.onSubmit(fields -> assertEquals("Value", fields.get("Test Field")));
+        this.form.submit();
+    }
+    
+    @Test
+    public void printsFieldDescriptionWhenFieldIsMarked() throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ConsolePaper subject = new ConsolePaper(new ByteArrayInputStream(System.lineSeparator().getBytes()), out);
+        
+        this.form.printOn(subject);
+        out.reset();
+        
+        this.form.markErrorsOn(subject);
+        
+        assertEquals(String.format("There are errors on the form:%n" +
+                                   "  - Test Field: Mandatory"),
+                     out.toString());
+    }
+    
+    @Test
+    public void defaultConstructorUsesSystemInOut() throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        
+        InputStream oldIn = System.in;
+        System.setIn(new ByteArrayInputStream(System.lineSeparator().getBytes()));
+        PrintStream oldOut = System.out;
+        System.setOut(new PrintStream(out));
+        
+        ConsolePaper subject = new ConsolePaper();
+        subject.printTitle("Hello World");
+        assertEquals(String.format("Hello World%n"), out.toString());
+        
+        System.setIn(oldIn);
+        System.setOut(oldOut);
+    }
+    
+    private final Form form = new TestForm();
+}

--- a/src/test/java/de/aliceice/paper/FormTest.java
+++ b/src/test/java/de/aliceice/paper/FormTest.java
@@ -67,8 +67,9 @@ public final class FormTest {
     }
     
     private void fillOutForm() {
-        this.subject.write("Field 1", "Hi");
-        this.subject.write("Field 2", "Hello World!");
+        this.paper.write("Field 1", "Hi");
+        this.paper.write("Field 2", "Hello World!");
+        this.paper.copyTo(this.subject);
     }
     
     private final Form      subject = new Form("Test Form",

--- a/src/test/java/de/aliceice/paper/TestForm.java
+++ b/src/test/java/de/aliceice/paper/TestForm.java
@@ -1,0 +1,10 @@
+package de.aliceice.paper;
+
+public final class TestForm extends Form {
+    
+    public TestForm() {
+        super("Test Form",
+              "Test Description",
+              new Fields(new Field("Test Field", new MandatoryRule())));
+    }
+}


### PR DESCRIPTION
To enable console applications to use this framework
a console specific paper implementation is needed.
This is implemented by using 'System.in/out' as
default input and output devices.

This fixes #12