### PR TITLE
Form names itself to strangers

### DIFF
--- a/src/main/java/de/aliceice/paper/Form.java
+++ b/src/main/java/de/aliceice/paper/Form.java
@@ -31,7 +31,11 @@ public class Form {
     public final void submit() {
         this.onSubmit.accept(this.fields.asMap());
     }
-    
+
+    public final String getName() {
+        return this.name;
+    }
+
     public Form(String name, Fields fields) {
         this(name, "", fields);
     }
@@ -48,4 +52,5 @@ public class Form {
     private final Fields fields;
     
     private Consumer<Map<String, String>> onSubmit;
+
 }

--- a/src/test/java/de/aliceice/paper/FormTest.java
+++ b/src/test/java/de/aliceice/paper/FormTest.java
@@ -65,6 +65,11 @@ public final class FormTest {
         
         assertEquals("{Field 1=Hi, Field 2=Hello World!}", reference.get());
     }
+
+    @Test
+    public void namesItselfToStrangers() throws Exception {
+        assertEquals("Test Form", this.subject.getName());
+    }
     
     private void fillOutForm() {
         this.paper.write("Field 1", "Hi");


### PR DESCRIPTION
A Form should always let strangers know its name if
they want it. This should enable more use cases in the future.

This fixes #17