### PR TITLE
TestPaper can now assert field values

### DIFF
--- a/src/main/java/de/aliceice/paper/ConsolePaper.java
+++ b/src/main/java/de/aliceice/paper/ConsolePaper.java
@@ -42,6 +42,11 @@ public final class ConsolePaper implements Paper {
         this.fieldValues.forEach(form::write);
     }
     
+    @Override
+    public Paper write(String name, String text) {
+        return this;
+    }
+    
     public ConsolePaper() {
         this(System.in, System.out);
     }

--- a/src/main/java/de/aliceice/paper/Field.java
+++ b/src/main/java/de/aliceice/paper/Field.java
@@ -7,6 +7,7 @@ public class Field {
     
     public final void printOn(Paper paper) {
         paper.printField(this.name, this.rules.getDescription());
+        paper.write(this.name, this.text);
     }
     
     public final Boolean isNotValid() {

--- a/src/main/java/de/aliceice/paper/Paper.java
+++ b/src/main/java/de/aliceice/paper/Paper.java
@@ -13,4 +13,6 @@ public interface Paper {
     void markErrorOn(String fieldName);
     
     void copyTo(Form form);
+    
+    Paper write(String name, String text);
 }

--- a/src/main/java/de/aliceice/paper/TestPaper.java
+++ b/src/main/java/de/aliceice/paper/TestPaper.java
@@ -42,6 +42,12 @@ public final class TestPaper implements Paper {
         this.fieldValues.forEach(form::write);
     }
     
+    @Override
+    public TestPaper write(String fieldName, String value) {
+        this.fieldValues.put(fieldName, value);
+        return this;
+    }
+    
     public TestPaper hasTitle(String title) {
         assertEquals(title, this.name);
         return this;
@@ -61,6 +67,14 @@ public final class TestPaper implements Paper {
         return this;
     }
     
+    public TestPaper hasFieldValue(String name, String value) {
+        assertTrue(this.fieldValues.containsKey(name),
+                   String.format("%s has no value.%n Available fields are: %s",
+                                 name, this.fieldValues.keySet()));
+        assertEquals(value, this.fieldValues.get(name));
+        return this;
+    }
+    
     public TestPaper isMarkedInvalid() {
         assertTrue(this.isMarkedInvalid);
         return this;
@@ -72,11 +86,6 @@ public final class TestPaper implements Paper {
                        String.format("%s is not marked as invalid. Marked fields are: %s",
                                      field, this.markedFields));
         });
-        return this;
-    }
-    
-    public TestPaper write(String fieldName, String value) {
-        this.fieldValues.put(fieldName, value);
         return this;
     }
     

--- a/src/test/java/de/aliceice/paper/ConsolePaperTest.java
+++ b/src/test/java/de/aliceice/paper/ConsolePaperTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(EnglishLocaleExtension.class)
@@ -61,6 +62,15 @@ public final class ConsolePaperTest {
         
         System.setIn(oldIn);
         System.setOut(oldOut);
+    }
+    
+    /**
+     * @todo: #26 write(name, text) must be implemented for ConsolePaper.
+     */
+    @Test
+    public void write() throws Exception {
+        ConsolePaper subject = new ConsolePaper();
+        assertSame(subject, subject.write("", ""));
     }
     
     private final Form form = new TestForm();

--- a/src/test/java/de/aliceice/paper/FormTest.java
+++ b/src/test/java/de/aliceice/paper/FormTest.java
@@ -36,6 +36,16 @@ public final class FormTest {
     }
     
     @Test
+    public void aFilledOutFormPrintsValuesToPaper() throws Exception {
+        this.subject.write("Field 1", "Value 1");
+        this.subject.write("Field 2", "Value 2");
+        this.subject.printOn(this.paper);
+        
+        this.paper.hasFieldValue("Field 1", "Value 1")
+                  .hasFieldValue("Field 2", "Value 2");
+    }
+    
+    @Test
     public void isValidIsFalseIfNothingHasBeenWrittenIntoTheForm() throws Exception {
         assertFalse(this.subject.isValid());
         assertTrue(this.subject.isNotValid());
@@ -67,7 +77,7 @@ public final class FormTest {
         
         assertEquals("{Field 1=Hi, Field 2=Hello World!}", reference.get());
     }
-
+    
     @Test
     public void namesItselfToStrangers() throws Exception {
         assertEquals("Test Form", this.subject.getName());


### PR DESCRIPTION
By letting the Field write it's current value onto the Paper
the Paper can be prefilled with either examples, notes or
already existing values. Furthermore it enables the TestPaper
to assert that a given field has a specific value.

This fixes #26