### PR TITLE
Implement RegexRule

### DIFF
--- a/src/main/java/de/aliceice/paper/RegexRule.java
+++ b/src/main/java/de/aliceice/paper/RegexRule.java
@@ -1,0 +1,24 @@
+package de.aliceice.paper;
+
+import java.util.regex.Pattern;
+
+public final class RegexRule extends LocalizedRule {
+    
+    @Override
+    public Boolean isValid(String value) {
+        return this.pattern.matcher(value).matches();
+    }
+    
+    public RegexRule(String regex, String example) {
+        this.pattern = Pattern.compile(regex, Pattern.DOTALL);
+        this.example = example;
+    }
+    
+    @Override
+    protected Object[] getDescriptionArguments() {
+        return new Object[] {this.example, this.pattern};
+    }
+    
+    private final Pattern pattern;
+    private final String  example;
+}

--- a/src/main/resources/Rules.properties
+++ b/src/main/resources/Rules.properties
@@ -2,3 +2,4 @@ FixedLengthRule=Fixed length %d
 FixedValueRule=Must be '%s'
 MandatoryRule=Mandatory
 MaxLengthRule=Max length %d
+RegexRule=Example: %s | Regular expression '%s'

--- a/src/main/resources/Rules_de.properties
+++ b/src/main/resources/Rules_de.properties
@@ -2,3 +2,4 @@ FixedLengthRule=Exakt %d Zeichen
 FixedValueRule=Muss '%s' sein
 MandatoryRule=Pflichtfeld
 MaxLengthRule=Maximal %d Zeichen
+RegexRule=Beispiel: %s | Regulärer Ausdruck '%s'

--- a/src/test/java/de/aliceice/paper/ConsolePaperTest.java
+++ b/src/test/java/de/aliceice/paper/ConsolePaperTest.java
@@ -65,7 +65,7 @@ public final class ConsolePaperTest {
     }
     
     /**
-     * @todo: #26 write(name, text) must be implemented for ConsolePaper.
+     * @todo #26 write(name, text) must be implemented for ConsolePaper.
      */
     @Test
     public void write() throws Exception {

--- a/src/test/java/de/aliceice/paper/RegexRuleTest.java
+++ b/src/test/java/de/aliceice/paper/RegexRuleTest.java
@@ -1,0 +1,31 @@
+package de.aliceice.paper;
+
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(EnglishLocaleExtension.class)
+public final class RegexRuleTest {
+    
+    @Test
+    public void description() throws Exception {
+        assertEquals(String.format("Example: 12345 | Regular expression '%s'", Pattern.compile("\\d{5}")),
+                     this.subject.getDescription());
+    }
+    
+    @Test
+    public void isValid() throws Exception {
+        assertTrue(this.subject.isValid("11111"));
+        assertTrue(this.subject.isValid("12345"));
+        assertFalse(this.subject.isNotValid("12345"));
+        assertTrue(this.subject.isNotValid("1234"));
+        assertTrue(this.subject.isNotValid("1234a"));
+        assertTrue(this.subject.isNotValid("abcde"));
+    }
+    
+    private final Rule subject = new RegexRule("\\d{5}", "12345");
+}


### PR DESCRIPTION
Many rules can possibly be expressed by a regular expression.
To simplify the rule description the RegexRule returns an
example instead of just the pattern.

This fixes #22