### PR TITLE
Add readSecret to Console

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <versions.build.findbugs-maven-plugin>3.0.4</versions.build.findbugs-maven-plugin>
         <versions.build.jacoco-maven-plugin>0.7.9</versions.build.jacoco-maven-plugin>
+        <versions.build.junit-surefire-provider>1.0.0-M4</versions.build.junit-surefire-provider>
         <versions.build.maven-checkstyle-plugin>2.17</versions.build.maven-checkstyle-plugin>
         <versions.build.maven-compiler-plugin>3.6.0</versions.build.maven-compiler-plugin>
         <versions.build.maven-deploy-plugin>2.8.2</versions.build.maven-deploy-plugin>
@@ -58,7 +59,7 @@
         <versions.build.maven-surefire-plugin>2.19</versions.build.maven-surefire-plugin>
         <versions.build.nexus-staging-maven-plugin>1.6.8</versions.build.nexus-staging-maven-plugin>
         <versions.build.versions-maven-plugin>2.1</versions.build.versions-maven-plugin>
-        <versions.dependencies.junit>5.0.0-M3</versions.dependencies.junit>
+        <versions.dependencies.junit>5.0.0-M4</versions.dependencies.junit>
         <versions.java>1.8</versions.java>
     </properties>
 
@@ -157,7 +158,7 @@
                     <dependency>
                         <groupId>org.junit.platform</groupId>
                         <artifactId>junit-platform-surefire-provider</artifactId>
-                        <version>1.0.0-M3</version>
+                        <version>${versions.build.junit-surefire-provider}</version>
                     </dependency>
                     <dependency>
                         <groupId>org.junit.jupiter</groupId>

--- a/src/main/java/de/aliceice/paper/Console.java
+++ b/src/main/java/de/aliceice/paper/Console.java
@@ -20,4 +20,9 @@ public interface Console {
     
     String readLine(String format, Object... args);
     
+    default String readSecret() {
+        return readSecret("");
+    }
+    
+    String readSecret(String format, Object... args);
 }

--- a/src/main/java/de/aliceice/paper/ConsolePaper.java
+++ b/src/main/java/de/aliceice/paper/ConsolePaper.java
@@ -49,13 +49,8 @@ public final class ConsolePaper implements Paper {
     public void askForInput() {
         this.fieldDescriptions.keySet()
                               .forEach(field -> {
-                                  this.console.printf(getPromptTemplate(field),
-                                                      field,
-                                                      this.fieldValues.get(field));
-            
-                                  String value = this.console.readLine();
                                   this.fieldValues.merge(field,
-                                                         value,
+                                                         getInput(field),
                                                          (oldValue, newValue) -> newValue.isEmpty()
                                                                                  ? oldValue
                                                                                  : newValue);
@@ -70,6 +65,15 @@ public final class ConsolePaper implements Paper {
         this.console = console;
         this.fieldDescriptions = new LinkedHashMap<>();
         this.fieldValues = new HashMap<>();
+    }
+    
+    private String getInput(String field) {
+        String prompt = String.format(getPromptTemplate(field),
+                                      field,
+                                      this.fieldValues.get(field));
+        return this.fieldDescriptions.get(field).contains("Secret")
+               ? this.console.readSecret(prompt)
+               : this.console.readLine(prompt);
     }
     
     private String getPromptTemplate(String field) {

--- a/src/main/java/de/aliceice/paper/IOStreamConsole.java
+++ b/src/main/java/de/aliceice/paper/IOStreamConsole.java
@@ -29,8 +29,14 @@ public final class IOStreamConsole implements Console {
     
     @Override
     public String readLine(String format, Object... args) {
-        this.out.printf(format, args);
+        printf(format, args);
         return this.in.nextLine();
+    }
+    
+    @Override
+    public String readSecret(String format, Object... args) {
+        println("WARNING: I/O Stream Console can't hide secrets. All input will be visible.");
+        return readLine(format, args);
     }
     
     public IOStreamConsole() {

--- a/src/main/java/de/aliceice/paper/SecretRule.java
+++ b/src/main/java/de/aliceice/paper/SecretRule.java
@@ -1,0 +1,14 @@
+package de.aliceice.paper;
+
+public final class SecretRule implements Rule {
+    
+    @Override
+    public String getDescription() {
+        return "Secret";
+    }
+    
+    @Override
+    public Boolean isValid(String value) {
+        return true;
+    }
+}

--- a/src/main/java/de/aliceice/paper/TestConsole.java
+++ b/src/main/java/de/aliceice/paper/TestConsole.java
@@ -29,8 +29,16 @@ public final class TestConsole implements Console {
     
     @Override
     public String readLine(String format, Object... args) {
-        this.output.append(String.format(format, args))
-                   .append(this.inputLines.peekFirst())
+        printf(format, args);
+        this.output.append(this.inputLines.peekFirst())
+                   .append(System.lineSeparator());
+        return this.inputLines.pollFirst();
+    }
+    
+    @Override
+    public String readSecret(String format, Object... args) {
+        printf(format, args);
+        this.output.append("***")
                    .append(System.lineSeparator());
         return this.inputLines.pollFirst();
     }

--- a/src/test/java/de/aliceice/paper/ConsolePaperTest.java
+++ b/src/test/java/de/aliceice/paper/ConsolePaperTest.java
@@ -15,7 +15,7 @@ public final class ConsolePaperTest {
     
     @Test
     public void printsOutputAndReadsFromInput() throws Exception {
-        this.console.useAsInput("Value");
+        this.console.useAsInput("Value", "Secret");
         
         this.form.printOn(subject);
         this.subject.askForInput();
@@ -23,10 +23,14 @@ public final class ConsolePaperTest {
         
         this.console.hasOutput("Test Form%n" +
                                "Test Description%n%n" +
-                               "Test Field: Value%n");
+                               "Test Field: Value%n" +
+                               "Secret Field: ***%n");
         
         assertTrue(this.form.isValid());
-        this.form.onSubmit(fields -> assertEquals("Value", fields.get("Test Field")));
+        this.form.onSubmit(fields -> {
+            assertEquals("Value", fields.get("Test Field"));
+            assertEquals("Secret", fields.get("Secret Field"));
+        });
         this.form.submit();
     }
     
@@ -49,12 +53,15 @@ public final class ConsolePaperTest {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         
         InputStream oldIn = System.in;
-        System.setIn(new ByteArrayInputStream(String.format("Value%n").getBytes()));
+        System.setIn(new ByteArrayInputStream(String.format("Value%nSecret%n").getBytes()));
         PrintStream oldOut = System.out;
         System.setOut(new PrintStream(out));
         
         ConsolePaper subject = new ConsolePaper();
-        this.form.printOn(subject);
+        new Form("Test Form",
+                 "Test Description",
+                 new Fields(new Field("Test Field")))
+            .printOn(subject);
         subject.askForInput();
         
         assertEquals(String.format("Test Form%n" +
@@ -69,7 +76,7 @@ public final class ConsolePaperTest {
     
     @Test
     public void write() throws Exception {
-        this.console.useAsInput("");
+        this.console.useAsInput("", "");
         this.form.write("Test Field", "Pre-Filled Value");
         this.form.printOn(subject);
         
@@ -78,7 +85,8 @@ public final class ConsolePaperTest {
         this.console.hasOutput("Test Form%n" +
                                "Test Description%n" +
                                "%n" +
-                               "Test Field (Currently 'Pre-Filled Value'): %n");
+                               "Test Field (Currently 'Pre-Filled Value'): %n" +
+                               "Secret Field: ***%n");
         
         this.form.onSubmit(fields -> assertEquals("Pre-Filled Value", fields.get("Test Field")));
         this.form.submit();

--- a/src/test/java/de/aliceice/paper/IOStreamConsoleTest.java
+++ b/src/test/java/de/aliceice/paper/IOStreamConsoleTest.java
@@ -39,4 +39,12 @@ public final class IOStreamConsoleTest {
         assertEquals("Input", subject.readLine());
     }
     
+    @Test
+    public void readSecret() throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        IOStreamConsole subject = new IOStreamConsole(new ByteArrayInputStream("Secret".getBytes()), out);
+        assertEquals("Secret", subject.readSecret());
+        assertEquals(String.format("WARNING: I/O Stream Console can't hide secrets. All input will be visible.%n"),
+                     out.toString());
+    }
 }

--- a/src/test/java/de/aliceice/paper/TestForm.java
+++ b/src/test/java/de/aliceice/paper/TestForm.java
@@ -7,6 +7,8 @@ public final class TestForm extends Form {
               "Test Description",
               new Fields(new Field("Test Field",
                                    new MandatoryRule(),
-                                   new MaxLengthRule(5))));
+                                   new MaxLengthRule(5)),
+                         new Field("Secret Field",
+                                   new SecretRule())));
     }
 }


### PR DESCRIPTION
A console should be able to read secrets. This includes
the necessity to mark specific fields as secret.

This fixes #55