### PR TITLE
Modify primary constructor of Rules

### DIFF
--- a/src/main/java/de/aliceice/paper/Rules.java
+++ b/src/main/java/de/aliceice/paper/Rules.java
@@ -17,7 +17,7 @@ public final class Rules {
                          .anyMatch(rule -> rule.isNotValid(value));
     }
     
-    public Rules(Rule[] rules) {
+    public Rules(Rule... rules) {
         this.rules = Arrays.asList(rules);
     }
     


### PR DESCRIPTION
Change the `Rule[]` parameter to vararg `Rule...` to ease the use of Rules

This fixes #60