### PR TITLE
ConsolePaper.markAsInvalid now uses `printErr` instead of `println`.

### DIFF
--- a/src/main/java/de/aliceice/paper/ConsolePaper.java
+++ b/src/main/java/de/aliceice/paper/ConsolePaper.java
@@ -27,7 +27,7 @@ public final class ConsolePaper implements Paper {
     
     @Override
     public void markAsInvalid() {
-        this.console.println("There are errors on the form:");
+        this.console.printErr(String.format("There are errors on the form:%n"));
     }
     
     @Override


### PR DESCRIPTION
This fixes #74